### PR TITLE
(#142) Document Certifier APIs in .h files. Refactor code. Add unit-tests.

### DIFF
--- a/include/certifier.h
+++ b/include/certifier.h
@@ -38,6 +38,7 @@
 
 #include "certifier_framework.h"
 
+// -------------------------------------------------------------------
 // Some Data and access functions
 // -------------------------------------------------------------------
 
@@ -50,23 +51,29 @@ const key_message* GetPublicPolicyKey();
 
 bool PublicKeyFromCert(const string& cert, key_message* k);
 
+bool GetParentEvidence(const string& enclave_type,
+                       const string& parent_enclave_type,
+                       string* out);
 
-bool GetParentEvidence(const string& enclave_type, const string& parent_enclave_type,
-      string* out);
-
-bool GetPlatformStatement(const string& enclave_type, const string& enclave_id,
-  int* size_out, byte* out);
+bool GetPlatformStatement(const string& enclave_type,
+                          const string& enclave_id,
+                          int* size_out, byte* out);
 
 
+// -------------------------------------------------------------------
 // Claims and proofs
 // -------------------------------------------------------------------
 
 bool make_attestation_user_data(const string& enclave_type,
-       const key_message& enclave_key, attestation_user_data* out);
-bool sign_report(const string& type, const string& report, const string& signing_alg,
-      const key_message& signing_key, string* serialized_signed_report);
+                                const key_message& enclave_key,
+                                attestation_user_data* out);
+
+bool sign_report(const string& type, const string& report,
+                 const string& signing_alg, const key_message& signing_key,
+                 string* serialized_signed_report);
+
 bool verify_report(string& type, string& serialized_signed_report,
-      const key_message& signer_key);
+                   const key_message& signer_key);
 
 void print_signed_report(const signed_report& sr);
 void print_user_data(attestation_user_data& at);
@@ -96,89 +103,151 @@ public:
   bool insert(const string& parent, const string& descendant);
   bool is_child(const string& descendant);
 };
-bool dominates(predicate_dominance& root, const string& parent, const string& descendant);
+bool dominates(predicate_dominance& root, const string& parent,
+               const string& descendant);
 
+// -------------------------------------------------------------
 // Certifier proofs
 // -------------------------------------------------------------
 
 bool statement_already_proved(const vse_clause& cl, proved_statements* are_proved);
 
-bool construct_vse_attestation_statement(const key_message& attest_key, const key_message& auth_key,
-        const string& measurement, vse_clause* vse_attest_clause);
+bool construct_vse_attestation_statement(const key_message& attest_key,
+                                         const key_message& auth_key,
+                                         const string& measurement,
+                                         vse_clause* vse_attest_clause);
+
 bool construct_what_to_say(string& enclave_type,
-      key_message& enclave_pk, string* what_to_say);
+                           key_message& enclave_pk,
+                           string* what_to_say);
+
 bool verify_signed_assertion_and_extract_clause(const key_message& key,
-      const signed_claim_message& sc, vse_clause* cl);
+                                                const signed_claim_message& sc,
+                                                vse_clause* cl);
 
 bool init_certifier_rules(certifier_rules& rules);
 bool init_axiom(key_message& pk, proved_statements* _proved);
-bool init_proved_statements(key_message& pk, evidence_package& evp,
-      proved_statements* already_proved);
+
+bool init_proved_statements(key_message& pk,
+                            evidence_package& evp,
+                            proved_statements* already_proved);
 
 bool verify_rule_1(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_rule_2(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_rule_3(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_rule_4(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_rule_5(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_rule_6(predicate_dominance& dom_tree, const vse_clause& c1,
-    const vse_clause& c2, const vse_clause& conclusion);
+                   const vse_clause& c2, const vse_clause& conclusion);
+
 bool verify_external_proof_step(predicate_dominance& dom_tree, proof_step& step);
+
 bool verify_internal_proof_step(predicate_dominance& dom_tree,
-        const vse_clause s1, const vse_clause s2,
-        const vse_clause conclude, int rule_to_apply);
+                                const vse_clause s1, const vse_clause s2,
+                                const vse_clause conclude, int rule_to_apply);
 
 bool verify_proof(key_message& policy_pk, vse_clause& to_prove,
-        predicate_dominance& dom_tree,
-        proof *the_proof, proved_statements* are_proved);
-bool add_fact_from_signed_claim(const signed_claim_message& signedClaim,
-    proved_statements* already_proved);
-bool add_newfacts_for_sdk_platform_attestation(key_message& policy_pk,
-      signed_claim_sequence& trusted_platforms, signed_claim_sequence& trusted_measurements,
-      proved_statements* already_proved);
-bool add_new_facts_for_abbreviatedplatformattestation(key_message& policy_pk,
-      signed_claim_sequence& trusted_platforms, signed_claim_sequence& trusted_measurements,
-      proved_statements* already_proved);
-bool construct_proof_from_sev_evidence(key_message& policy_pk, const string& purpose,
-      proved_statements* already_proved, vse_clause* to_prove, proof* pf);
-bool construct_proof_from_sdk_evidence(key_message& policy_pk, const string& purpose,
-      proved_statements* already_proved,
-      vse_clause* to_prove, proof* pf);
-bool construct_proof_from_full_vse_evidence(key_message& policy_pk,
-      const string& purpose, proved_statements* already_proved,
-      vse_clause* to_prove, proof* pf);
-bool construct_proof_from_request(const string& evidence_descriptor, key_message& policy_pk,
-      const string& purpose, signed_claim_sequence& trusted_platforms,
-      signed_claim_sequence& trusted_measurements, evidence_package& evp,
-      proved_statements* already_proved, vse_clause* to_prove, proof* pf);
-bool validate_evidence(const string& evidence_descriptor,
-      signed_claim_sequence& trusted_platforms, signed_claim_sequence& trusted_measurements,
-      const string& purpose, evidence_package& evp, key_message& policy_pk);
+                  predicate_dominance& dom_tree,
+                  proof *the_proof, proved_statements* are_proved);
 
-bool get_platform_from_sev_attest(const sev_attestation_message& sev_att, entity_message* ent);
+bool add_fact_from_signed_claim(const signed_claim_message& signedClaim,
+                                proved_statements* already_proved);
+
+bool add_newfacts_for_sdk_platform_attestation(
+                            key_message& policy_pk,
+                            signed_claim_sequence& trusted_platforms,
+                            signed_claim_sequence& trusted_measurements,
+                            proved_statements* already_proved);
+
+bool add_new_facts_for_abbreviatedplatformattestation(
+                            key_message& policy_pk,
+                            signed_claim_sequence& trusted_platforms,
+                            signed_claim_sequence& trusted_measurements,
+                            proved_statements* already_proved);
+
+bool construct_proof_from_sev_evidence(key_message& policy_pk,
+                                       const string& purpose,
+                                       proved_statements* already_proved,
+                                       vse_clause* to_prove,
+                                       proof* pf);
+
+bool construct_proof_from_sdk_evidence(key_message& policy_pk,
+                                       const string& purpose,
+                                       proved_statements* already_proved,
+                                       vse_clause* to_prove,
+                                       proof* pf);
+
+bool construct_proof_from_full_vse_evidence(key_message& policy_pk,
+                                            const string& purpose,
+                                            proved_statements* already_proved,
+                                            vse_clause* to_prove,
+                                            proof* pf);
+
+bool construct_proof_from_request(const string& evidence_descriptor,
+                                  key_message& policy_pk,
+                                  const string& purpose,
+                                  signed_claim_sequence& trusted_platforms,
+                                  signed_claim_sequence& trusted_measurements,
+                                  evidence_package& evp,
+                                  proved_statements* already_proved,
+                                  vse_clause* to_prove,
+                                  proof* pf);
+
+bool validate_evidence(const string& evidence_descriptor,
+                       signed_claim_sequence& trusted_platforms,
+                       signed_claim_sequence& trusted_measurements,
+                       const string& purpose,
+                       evidence_package& evp,
+                       key_message& policy_pk);
+
+bool get_platform_from_sev_attest(const sev_attestation_message& sev_att,
+                                  entity_message* ent);
+
 bool get_measurement_from_sev_attest(const sev_attestation_message& sev_att,
-      entity_message* ent);
-bool filter_sev_policy(const sev_attestation_message& sev_att, const key_message& policy_pk,
-        const signed_claim_sequence& policy,
-        signed_claim_sequence* filtered_policy);
-bool init_policy(signed_claim_sequence& policy, key_message& policy_pk,
-      proved_statements* already_proved);
-bool construct_proof_from_sev_evidence_with_plat(const string& evidence_descriptor,
-      key_message& policy_pk, const string& purpose,
-      proved_statements* already_proved, vse_clause* to_prove, proof* pf,
-      // the following is temporary till we figure out the proto problem
-      proof_step* pss, int* num);
-bool verify_proof_from_array(key_message& policy_pk, vse_clause& to_prove,
-        predicate_dominance& dom_tree,
-        proved_statements* are_proved, int num_steps, proof_step* steps);
+                                     entity_message* ent);
+
+bool filter_sev_policy(const sev_attestation_message& sev_att,
+                       const key_message& policy_pk,
+                       const signed_claim_sequence& policy,
+                       signed_claim_sequence* filtered_policy);
+
+bool init_policy(signed_claim_sequence& policy,
+                 key_message& policy_pk,
+                 proved_statements* already_proved);
+
+bool construct_proof_from_sev_evidence_with_plat(
+                        const string& evidence_descriptor,
+                        key_message& policy_pk,
+                        const string& purpose,
+                        proved_statements* already_proved,
+                        vse_clause* to_prove,
+                        proof* pf,
+                        // the following is temporary till we figure out the proto problem
+                        proof_step* pss, int* num);
+
+bool verify_proof_from_array(key_message& policy_pk,
+                             vse_clause& to_prove,
+                             predicate_dominance& dom_tree,
+                             proved_statements* are_proved,
+                             int num_steps,
+                             proof_step* steps);
+
 bool validate_evidence_from_policy(const string& evidence_descriptor,
-        signed_claim_sequence& policy, const string& purpose,
-        evidence_package& evp, key_message& policy_pk);
+                                   signed_claim_sequence& policy,
+                                   const string& purpose,
+                                   evidence_package& evp,
+                                   key_message& policy_pk);
 
 // -------------------------------------------------------------------
 
-#endif
+#endif // _CERTIFIER_H__

--- a/include/certifier_framework.h
+++ b/include/certifier_framework.h
@@ -29,7 +29,8 @@ typedef unsigned char byte;
 
 using std::string;
 
-// Policy store
+// -------------------------------------------------------------------
+// Policy store: Manage storage and administration of policies.
 // -------------------------------------------------------------------
 
 namespace certifier {
@@ -42,34 +43,70 @@ namespace certifier {
       key_message policy_key_;
       string encryption_algorithm_;
 
+      // -------------------------------------------------------------------
+      // Different types of artifacts that are tracked in the Policy Store
+      // -------------------------------------------------------------------
+      //
+      trusted_service_message** ts_;
       int max_num_ts_;
       int num_ts_;
-      trusted_service_message** ts_;
+
+      tagged_signed_claim** tsc_;
       int max_num_tsc_;
       int num_tsc_;
-      tagged_signed_claim** tsc_;
+
+      storage_info_message** si_;
       int max_num_si_;
       int num_si_;
-      storage_info_message** si_;
+
+      tagged_claim** tc_;
       int max_num_tc_;
       int num_tc_;
-      tagged_claim** tc_;
+
+      channel_key_message** tkm_;
       int max_num_tkm_;
       int num_tkm_;
-      channel_key_message** tkm_;
+
+      tagged_blob_message** tagged_blob_;
       int max_num_blobs_;
       int num_blobs_;
-      tagged_blob_message** tagged_blob_;
 
     public:
 
+      // Default capacity for artifacts in store is MAX_NUM_ENTRIES for
+      // each type of artifact defined above.
       policy_store();
-      policy_store(const string enc_alg, int max_trusted_services, int max_trusted_signed_claims,
-          int max_storage_infos, int max_claims, int max_keys, int max_blobs);
+
+      // Initialize a Policy Store for an encryption algorithm specifying
+      // the capacity of the store in terms of max-numbers of artifacts
+      // that can be tracked.
+      policy_store(const string enc_alg, int max_trusted_services,
+                   int max_trusted_signed_claims, int max_storage_infos,
+                   int max_claims, int max_keys, int max_blobs);
       ~policy_store();
 
+      // Initialize / replace the policy key using input message 'k'
       bool replace_policy_key(key_message& k);
+
+      // Return current policy key, if initialized. Null otherwise.
       const key_message* get_policy_key();
+
+      // ----------------------------------------------------------------
+      // Each artifact ('entity') tracked in the store has these interfaces:
+      //
+      //  - get_num_<entity> - Return # of entities tracked
+      //  - get_<entity>_by_index() - Return handle to entity by its index
+      //    Returns NULL, if index is invalid.
+      //
+      //  - get_<entity>_index_by_tag()- Return index of entity by its 'tag'
+      //  - add_<entity>() - Add a new entity to the store.
+      //    Returns True on success. False otherwise (store is full)
+      //
+      //  - delete_<entity>_by_index() - Delete an entity, by its index
+      //    List of entities is compacted after deleting specified item,
+      //    so that there are no 'holes' in tracking array.
+      //    Returns nothing. Object will be deleted if found.
+      // ----------------------------------------------------------------
 
       int get_num_trusted_services();
       const trusted_service_message* get_trusted_service_info_by_index(int n);
@@ -109,40 +146,155 @@ namespace certifier {
       void delete_blob_by_index(int index);
       int get_num_blobs();
 
+      // Serialize contents of the policy store.
+      // Returns True on success, False otherwise
       bool Serialize(string* out);
+
+      // Deserialize the input string into the contents of the policy store.
+      // Returns True on success, False otherwise
       bool Deserialize(string& in);
 
+      // Delete all artifacts tracked in the policy store, releasing any
+      // memory used. (Currently unimplemented.)
       void clear_policy_store();
     };
+
+    // Print summary details of the contents of the policy store
     void print_store(policy_store& ps);
 
-    // Trusted primitives
-    // -------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // Trusted primitives for use on the following enclave types:
+    //
+    //  - "simulated-enclave"
+    //  - "oe-enclave"
+    //  - "sev-enclave"
+    //  - "asylo-enclave"       [ Support deprecated ]
+    //  - "gramine-enclave"
+    //  - "keystone-enclave"
+    //  - "islet-enclave"
+    //  - "application-enclave"
+    // ------------------------------------------------------------------------
 
+    // ------------------------------------------------------------------------
+    // Encrypt an enclave's states for persistent storage outside of an enclave.
+    // Encryption is performed using a private seal key, derived from the TEE
+    // system the enclave is running on.
+    //
+    // Parameters:
+    // - enclave_type - String describing the enclave type. (See above)
+    // - enclavd_id - String identifying the enclave type. (Currently unused)
+    // - in_size - Size of input stream 'in'
+    // - in - Input byte stream containing secret data to be sealed
+    // - size_out - (Out) Size of sealed output stream 'out'
+    // - out - Sealed output byte stream
+    //
+    // Returns: True on a successful seal operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Seal(const string& enclave_type, const string& enclave_id,
-      int in_size, byte* in, int* size_out, byte* out);
+              int in_size, byte* in, int* size_out, byte* out);
 
+    // ------------------------------------------------------------------------
+    // Decrypt an enclave's sealed data using the same key used for sealing.
+    // This allows an enclave's state to be restored when the same enclave is
+    // subsequently brought back up.
+    //
+    // Parameters:
+    // - enclave_type - String describing the enclave type. (See above)
+    // - enclavd_id - String identifying the enclave type. (Currently unused)
+    // - in_size - Size of input stream 'in'
+    // - in - Input byte stream containing secret data to be sealed
+    // - size_out - (Out) Size of sealed output stream 'out'
+    // - out - Sealed output byte stream
+    //
+    // Returns: True on a successful unseal operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Unseal(const string& enclave_type, const string& enclave_id,
-      int in_size, byte* in, int* size_out, byte* out);
+                int in_size, byte* in, int* size_out, byte* out);
 
+    // ------------------------------------------------------------------------
+    // Interface that allows a program to establish a trusted relationship
+    // with another program over an insecure communication channel.
+    // An attestation-capable platform accepts a statement called "What the
+    // program says" from the program issuing this call. The platform signs the
+    // statement using a private-key known only by the platform. The signed
+    // statement, known as the attestation, is returned in the 'out' parameter.
+    //
+    // Parameters:
+    // - enclave_type - String describing the enclave type. (See above)
+    // - what_to_say_size - Length of 'what_to_say' argument.
+    // - what_to_say - What-the-program-says string
+    // - size_out - Size of the attestation result, returned in 'out'
+    // - out - Attestation result
+    //
+    // Returns: True on a successful unseal operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Attest(const string& enclave_type,
-      int what_to_say_size, byte* what_to_say,
-      int* size_out, byte* out);
+                int what_to_say_size, byte* what_to_say,
+                int* size_out, byte* out);
 
-    // Protect Support
+    // -------------------------------------------------------------------
+    // Protect Support: Wrappers around platform-specific Seal(), Unseal()
     // -------------------------------------------------------------------
 
+    // ------------------------------------------------------------------------
+    // Protect unencrypted data using user-specified 'key'. This uses the
+    // platform-specific Seal() interface.
+    //
+    // Parameters:
+    // - enclave_type - String describing the enclave type. (See above)
+    // - key - User-defined 'key'
+    // - size_unencrypted_data - Length of unencrypted (input) data
+    // - unencrypted_data - Unencrypted (input) data
+    // - size_protected_blob - (Out) Length of encrypted data, 'blob'
+    // - blob - (Out) Encrypted data
+    //
+    // Returns: True on a successful operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Protect_Blob(const string& enclave_type,
-      key_message& key, int size_unencrypted_data, byte* unencrypted_data,
-      int* size_protected_blob, byte* blob);
+                      key_message& key, int size_unencrypted_data,
+                      byte* unencrypted_data, int* size_protected_blob,
+                      byte* blob);
+
+    // ------------------------------------------------------------------------
+    // Unprotect the encrypted data. This uses the platform-specific Unseal()
+    // interface.
+    //
+    // Parameters:
+    // - enclave_type - String describing the enclave type. (See above)
+    // - size_protected_blob, - Length of encrypted (input) data
+    // - protected_blob - Encrypted (input) data
+    // - key - (Out) User-defined 'key' that was used for protection
+    // - size_of_unencrypted_data - (Out) Length of unencrypted data, 'data'
+    // - data - (Out) Unencrypted data
+    //
+    // Returns: True on a successful operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Unprotect_Blob(const string& enclave_type,
-      int size_protected_blob, byte* protected_blob,
-      key_message* key, int* size_of_unencrypted_data, byte* data);
+                        int size_protected_blob, byte* protected_blob,
+                        key_message* key, int* size_of_unencrypted_data,
+                        byte* data);
+
+    // ------------------------------------------------------------------------
+    // Reprotect an encrypted data with an internally-generated new key that
+    // is used for re-protecting the data. (RESOLVE: How does this business of
+    // cipher_key_byte_size() in implementation work out.)
+    //
+    // - enclave_type - String describing the enclave type. (See above)
+    // - key - RESOLVE: Is unused in implementation
+    // - size_protected_blob, - Length of encrypted (input) data
+    // - protected_blob - Encrypted (input) data
+    // - size_new_encrypted_blob - (Out) Length of re-encrypted data, 'data'
+    // - data - (Out) Newly encrypted data
+    //
+    // Returns: True on a successful operation. False, otherwise
+    // ------------------------------------------------------------------------
     bool Reprotect_Blob(const string& enclave_type, key_message* key,
-      int size_protected_blob, byte* protected_blob,
-      int* size_new_encrypted_blob, byte* data);
+                        int size_protected_blob, byte* protected_blob,
+                        int* size_new_encrypted_blob, byte* data);
 
-
+    // ------------------------------------------------------------------
+    // Manage trust-related attributes of the enclosing Policy Store.
+    // ------------------------------------------------------------------
     class cc_trust_data {
 
     static const int max_symmetric_key_size_ = 128;
@@ -198,21 +350,27 @@ namespace certifier {
 
       cc_trust_data();
       cc_trust_data(const string& enclave_type, const string& purpose,
-          const string& policy_store_name);
+                    const string& policy_store_name);
       ~cc_trust_data();
 
       // Each of the enclave types have bespoke initialization
       bool initialize_simulated_enclave_data(const string& attest_key_file_name,
-          const string& measurement_file_name, const string& attest_endorsement_file_name);
+                                             const string& measurement_file_name,
+                                             const string& attest_endorsement_file_name);
+
       bool initialize_sev_enclave_data(const string& platform_ark_der_file,
-          const string& platform_ask_der_file,
-          const string& platform_vcek_der_file);
+                                       const string& platform_ask_der_file,
+                                       const string& platform_vcek_der_file);
+
       bool initialize_gramine_enclave_data(const int size, byte* cert);
       bool initialize_oe_enclave_data(const string& file);
+
       bool initialize_application_enclave_data(const string& parent_enclave_type,
-              int in_fd, int out_fd);
+                                               int in_fd, int out_fd);
+
       bool initialize_keystone_enclave_data(const string& attest_key_file_name,
-          const string& measurement_file_name, const string& attest_endorsement_file_name);
+                                            const string& measurement_file_name,
+                                            const string& attest_endorsement_file_name);
 
       bool initialize_islet_enclave_data(const string& attest_key_file_name,
                                          const string& measurement_file_name,
@@ -239,6 +397,10 @@ namespace certifier {
       bool run_peer_certificationservice(const string& host_name, int port);
     };
 
+    // ------------------------------------------------------------------
+    // Manage attributes of the secured authenticated channel between
+    // client and server process ... RESOLVE ??? Clarify ...
+    // ------------------------------------------------------------------
     class secure_authenticated_channel {
     public:
       string role_;
@@ -260,10 +422,13 @@ namespace certifier {
 
       bool load_client_certs_and_key();
 
-      bool init_client_ssl(const string& host_name, int port, string& asn1_root_cert,
-          key_message& private_key, const string& private_key_cert);
-      bool init_server_ssl(const string& host_name, int port, string& asn1_root_cert,
-          key_message& private_key, const string& private_key_cert);
+      bool init_client_ssl(const string& host_name, int port,
+                           string& asn1_root_cert, key_message& private_key,
+                           const string& private_key_cert);
+
+      bool init_server_ssl(const string& host_name, int port,
+                           string& asn1_root_cert, key_message& private_key,
+                           const string& private_key_cert);
 
       void server_channel_accept_and_auth(void (*func)(secure_authenticated_channel&));
 
@@ -276,8 +441,9 @@ namespace certifier {
 
     bool server_dispatch(const string& host_name, int port,
                          string& asn1_root_cert, key_message& private_key,
-                         const string& private_key_cert, void (*)(secure_authenticated_channel&));
+                         const string& private_key_cert,
+                         void (*)(secure_authenticated_channel&));
   }
 }
 
-#endif
+#endif // _CERTIFIER_FRAMEWORK_H__

--- a/include/certifier_utilities.h
+++ b/include/certifier_utilities.h
@@ -39,13 +39,14 @@ namespace certifier {
     bool read_file_into_string(const string& file_name, string* out);
 
     bool digest_message(const char* alg, const byte* message, int message_len,
-        byte* digest, unsigned int digest_len);
+                        byte* digest, unsigned int digest_len);
 
 
     bool authenticated_encrypt(const char* alg, byte* in, int in_len, byte *key,
-                byte *iv, byte *out, int* out_size);
+                               byte *iv, byte *out, int* out_size);
+
     bool authenticated_decrypt(const char* alg, byte* in, int in_len, byte *key,
-                byte *out, int* out_size);
+                               byte *out, int* out_size);
 
     EC_KEY* generate_new_ecc_key(int num_bits);
     EC_KEY* key_to_ECC(const key_message& kr);
@@ -77,13 +78,16 @@ namespace certifier {
 
     // X509 artifact
     bool produce_artifact(key_message& signing_key, string& issuer_name_str,
-          string& issuer_description_str, key_message& subject_key,
-          string& subject_name_str, string& subject_description_str,
-          uint64_t sn, double secs_duration, X509* x509, bool is_root);
+                          string& issuer_description_str,
+                          key_message& subject_key, string& subject_name_str,
+                          string& subject_description_str, uint64_t sn,
+                          double secs_duration, X509* x509, bool is_root);
+
     bool verify_artifact(X509& cert, key_message& verify_key,
-        string* issuer_name_str, string* issuer_description_str,
-        key_message* subject_key, string* subject_name_str, string* subject_description_str,
-        uint64_t* sn);
+                         string* issuer_name_str,
+                         string* issuer_description_str,
+                         key_message* subject_key,string* subject_name_str,
+                         string* subject_description_str, uint64_t* sn);
 
     int cipher_block_byte_size(const char* alg_name);
     int cipher_key_byte_size(const char* alg_name);
@@ -92,7 +96,9 @@ namespace certifier {
 
     bool asn1_to_x509(const string& in, X509 *x);
     bool x509_to_asn1(X509 *x, string* out);
-    bool make_root_key_with_cert(string& type, string& name, string& issuer_name, key_message* k);
+
+    bool make_root_key_with_cert(string& type, string& name,
+                                 string& issuer_name, key_message* k);
 
     bool check_date_range(const string& nb, const string& na);
 
@@ -101,4 +107,4 @@ namespace certifier {
   }
 }
 
-#endif
+#endif // _CERTIFIER_UTILITIES_H__

--- a/src/cc_helpers.cc
+++ b/src/cc_helpers.cc
@@ -66,6 +66,7 @@ extern bool gramine_platform_cert_initialized;
 extern string gramine_platform_cert;
 #endif
 
+// ----------------------------------------------------------------------------
 //  This is a collection of functions that accomplish almost all the
 //  Confidential Computing functions for basic enclaves including:
 //    Initializing policy key information
@@ -76,12 +77,14 @@ extern string gramine_platform_cert;
 //    Encrypting and saving the policy store
 //    Reading and decrypting the policy store and filling in trust data from it
 //
-//  You may want to augment these or write replacements if your needs are fancier.
+// You may want to augment these or write replacements if your needs are fancier.
+// ----------------------------------------------------------------------------
 
 //#define DEBUG
 
-certifier::framework::cc_trust_data::cc_trust_data(const string& enclave_type, const string& purpose,
-    const string& policy_store_name) {
+certifier::framework::cc_trust_data::cc_trust_data(const string& enclave_type,
+                                                   const string& purpose,
+                                                   const string& policy_store_name) {
 
   if (purpose == "authentication" || purpose == "attestation") {
     purpose_= purpose;
@@ -135,8 +138,9 @@ bool certifier::framework::cc_trust_data::cc_all_initialized() {
   }
 }
 
-bool certifier::framework::cc_trust_data::initialize_application_enclave_data(const string& parent_enclave_type,
-    int in_fd, int out_fd) {
+bool certifier::framework::cc_trust_data::initialize_application_enclave_data(
+                                const string& parent_enclave_type,
+                                int in_fd, int out_fd) {
 
    if (!cc_policy_info_initialized_) {
       printf("initialize_application_enclave_data: Policy key must be initialized first\n");
@@ -155,8 +159,10 @@ bool certifier::framework::cc_trust_data::initialize_application_enclave_data(co
   return true;
 }
 
-bool certifier::framework::cc_trust_data::initialize_simulated_enclave_data(const string& attest_key_file_name,
-      const string& measurement_file_name, const string& attest_endorsement_file_name) {
+bool certifier::framework::cc_trust_data::initialize_simulated_enclave_data(
+                                const string& attest_key_file_name,
+                                const string& measurement_file_name,
+                                const string& attest_endorsement_file_name) {
 
     if (!cc_policy_info_initialized_) {
       printf("initialize_simulated_enclave_data: Policy key must be initialized first\n");
@@ -344,7 +350,8 @@ void certifier::framework::cc_trust_data::print_trust_data() {
 
   if (cc_service_cert_initialized_) {
     printf("Serialised service cert:\n");
-    print_bytes(serialized_service_cert_.size(), (byte*)serialized_service_cert_.data());
+    print_bytes(serialized_service_cert_.size(),
+                (byte*)serialized_service_cert_.data());
     printf("\n\n");
   }
   if (cc_service_platform_rule_initialized_) {
@@ -424,7 +431,7 @@ bool certifier::framework::cc_trust_data::save_store() {
     return false;
   }
 
-  int size_protected_blob= serialized_store.size() + max_pad_size_for_store;
+  int size_protected_blob = serialized_store.size() + max_pad_size_for_store;
   byte protected_blob[size_protected_blob];
 
   byte pkb[max_symmetric_key_size_];
@@ -446,7 +453,8 @@ bool certifier::framework::cc_trust_data::save_store() {
   pk.set_secret_key_bits(pkb, num_key_bytes);
 
   if (!Protect_Blob(enclave_type_, pk, serialized_store.size(),
-          (byte*)serialized_store.data(), &size_protected_blob, protected_blob)) {
+                    (byte*)serialized_store.data(),
+                    &size_protected_blob, protected_blob)) {
     printf("save_store: can't protect blob\n");
     return false;
   }
@@ -484,7 +492,7 @@ bool certifier::framework::cc_trust_data::fetch_store() {
   pk.set_key_format("vse-key");
 
   if (!Unprotect_Blob(enclave_type_, size_protected_blob, protected_blob,
-        &pk, &size_unprotected_blob, unprotected_blob)) {
+                      &pk, &size_unprotected_blob, unprotected_blob)) {
     printf("%s(): Can't Unprotect\n", __func__);
     return false;
   }
@@ -701,12 +709,14 @@ bool certifier::framework::cc_trust_data::get_trust_data_from_store() {
   return false;
 }
 
+// -----------------------------------------------------------------------------
 //  public_key_alg can be rsa-2048 (soon: rsa-1024, rsa-4096, ecc-384)
 //  symmetric_key_alg can be aes-256
 //  hash_alg can be sha-256 (soon: sha-384, sha-512)
 //  hmac-alg can be sha-256-hmac (soon: sha-384-hmac, sha-512-hmac)
+// -----------------------------------------------------------------------------
 bool certifier::framework::cc_trust_data::cold_init(const string& public_key_alg,
-        const string& symmetric_key_alg) {
+                                                    const string& symmetric_key_alg) {
 
   if (!cc_policy_info_initialized_) {
       printf("cold_init: policy key should have been initialized\n");
@@ -896,7 +906,9 @@ bool certifier::framework::cc_trust_data::GetPlatformSaysAttestClaim(signed_clai
   return false;
 }
 
-bool certifier::framework::cc_trust_data::recertify_me(const string& host_name, int port, bool generate_new_key) {
+bool certifier::framework::cc_trust_data::recertify_me(const string& host_name,
+                                                       int port,
+                                                       bool generate_new_key) {
 
   if (generate_new_key) {
 
@@ -992,7 +1004,8 @@ bool certifier::framework::cc_trust_data::recertify_me(const string& host_name, 
   return true;
 }
 
-bool certifier::framework::cc_trust_data::certify_me(const string& host_name, int port) {
+bool certifier::framework::cc_trust_data::certify_me(const string& host_name,
+                                                     int port) {
 
   if (!cc_all_initialized()) {
     if (!warm_restart()) {
@@ -1109,7 +1122,7 @@ bool certifier::framework::cc_trust_data::certify_me(const string& host_name, in
 #endif
 
     if (!make_attestation_user_data(enclave_type_,
-          public_auth_key_, &ud)) {
+                                    public_auth_key_, &ud)) {
       printf("certifier::framework::cc_trust_data::certify_me: Can't make user data (1)\n");
       return false;
     }
@@ -1128,7 +1141,7 @@ bool certifier::framework::cc_trust_data::certify_me(const string& host_name, in
 #endif
   } else if (purpose_ == "attestation") {
     if (!make_attestation_user_data(enclave_type_,
-          public_service_key_, &ud)) {
+                                    public_service_key_, &ud)) {
       printf("certifier::framework::cc_trust_data::certify_me: Can't make user data (1)\n");
       return false;
     }
@@ -1153,7 +1166,7 @@ bool certifier::framework::cc_trust_data::certify_me(const string& host_name, in
   int size_out = 16000;
   byte out[size_out];
   if (!Attest(enclave_type_, serialized_ud.size(),
-        (byte*) serialized_ud.data(), &size_out, out)) {
+              (byte*) serialized_ud.data(), &size_out, out)) {
     printf("certifier::framework::cc_trust_data::certify_me():%d: Attest failed\n", __LINE__);
     return false;
   }
@@ -1168,7 +1181,9 @@ bool certifier::framework::cc_trust_data::certify_me(const string& host_name, in
   //   to prevent MITM attacks?  Probably not.
   request.set_requesting_enclave_tag("requesting-enclave");
   request.set_providing_enclave_tag("providing-enclave");
-  if (enclave_type_ == "application-enclave" || enclave_type_ == "simulated-enclave") {
+
+  if (   (enclave_type_ == "application-enclave")
+      || (enclave_type_ == "simulated-enclave")) {
     request.set_submitted_evidence_type("vse-attestation-package");
   } else if (enclave_type_ == "sev-enclave") {
     request.set_submitted_evidence_type("sev-platform-package");
@@ -1189,8 +1204,9 @@ bool certifier::framework::cc_trust_data::certify_me(const string& host_name, in
   // Put initialized platform evidence and attestation in the following order:
   //  platform_says_attest_key_is_trusted, the_attestation
   evidence_package* ep = new(evidence_package);
-  if (!construct_platform_evidence_package(enclave_type_, purpose_, platform_evidence,
-        the_attestation_str, ep))  {
+  if (!construct_platform_evidence_package(enclave_type_, purpose_,
+                                           platform_evidence,
+                                           the_attestation_str, ep))  {
     printf("certifier::framework::cc_trust_data::certify_me: construct_platform_evidence_package failed\n");
     return false;
   }
@@ -1334,9 +1350,11 @@ bool certifier::framework::cc_trust_data::run_peer_certificationservice(const st
 // --------------------------------------------------------------------------------------
 // helpers for proofs
 
-bool construct_platform_evidence_package(string& attesting_enclave_type, const string& purpose,
-      evidence_list& platform_assertions, string& serialized_attestation,
-      evidence_package* ep) {
+bool construct_platform_evidence_package(string& attesting_enclave_type,
+                                         const string& purpose,
+                                         evidence_list& platform_assertions,
+                                         string& serialized_attestation,
+                                         evidence_package* ep) {
 
   string pt("vse-verifier");
   string et("signed-claim");
@@ -1391,8 +1409,9 @@ bool construct_platform_evidence_package(string& attesting_enclave_type, const s
 }
 
 // Todo: This isn't used
-bool add_policy_key_says_platform_key_is_trusted(signed_claim_message& platform_key_is_trusted,
-      evidence_package* ep) {
+bool add_policy_key_says_platform_key_is_trusted(
+                signed_claim_message& platform_key_is_trusted,
+                evidence_package* ep) {
 
   string et("signed-claim");
 
@@ -1623,7 +1642,7 @@ bool extract_id_from_cert(X509* in, string* out) {
 
 // Loads server side certs and keys.
 bool load_server_certs_and_key(X509* root_cert,
-      key_message& private_key, SSL_CTX* ctx) {
+                               key_message& private_key, SSL_CTX* ctx) {
   // load auth key, policy_cert and certificate chain
   // Todo: Add other key types
   RSA* r = RSA_new();
@@ -1704,8 +1723,10 @@ bool load_server_certs_and_key(X509* root_cert,
 }
 
 bool certifier::framework::server_dispatch(const string& host_name, int port,
-      string& asn1_root_cert, key_message& private_key,
-      const string& private_key_cert, void (*func)(secure_authenticated_channel&)) {
+                                           string& asn1_root_cert,
+                                           key_message& private_key,
+                                           const string& private_key_cert,
+                                           void (*func)(secure_authenticated_channel&)) {
 
   OPENSSL_init_ssl(0, NULL);
   SSL_load_error_strings();
@@ -1818,8 +1839,12 @@ certifier::framework::secure_authenticated_channel::~secure_authenticated_channe
   peer_id_.clear();
 }
 
-bool certifier::framework::secure_authenticated_channel::init_client_ssl(const string& host_name, int port,
-        string& asn1_root_cert, key_message& private_key, const string& auth_cert) {
+bool certifier::framework::secure_authenticated_channel::init_client_ssl(
+                        const string& host_name,
+                        int port,
+                        string& asn1_root_cert,
+                        key_message& private_key,
+                        const string& auth_cert) {
 
   OPENSSL_init_ssl(0, NULL);
   SSL_load_error_strings();
@@ -2014,8 +2039,13 @@ void certifier::framework::secure_authenticated_channel::server_channel_accept_a
   return;
 }
 
-bool certifier::framework::secure_authenticated_channel::init_server_ssl(const string& host_name,
-      int port, string& asn1_root_cert, key_message& private_key, const string& auth_cert) {
+bool certifier::framework::secure_authenticated_channel::init_server_ssl(
+                        const string& host_name,
+                        int port,
+                        string& asn1_root_cert,
+                        key_message& private_key,
+                        const string& auth_cert) {
+
   SSL_load_error_strings();
 
   // set keys and cert

--- a/src/certifier_tests.cc
+++ b/src/certifier_tests.cc
@@ -1,10 +1,3 @@
-#include <gtest/gtest.h>
-#include <gflags/gflags.h>
-
-#include "certifier.h"
-#include "support.h"
-#include "simulated_enclave.h"
-
 //  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+
+#include "certifier.h"
+#include "support.h"
+#include "simulated_enclave.h"
 
 
 DEFINE_bool(print_all, false,  "verbose");
@@ -96,6 +96,12 @@ extern bool test_policy_store(bool print_all);
 TEST (policy_store, test_policy_store) {
   EXPECT_TRUE(test_policy_store(FLAGS_print_all));
 }
+
+extern bool test_policy_store_signed_claims(bool print_all);
+TEST (policy_store, test_policy_store_signed_claims) {
+  EXPECT_TRUE(test_policy_store_signed_claims(FLAGS_print_all));
+}
+
 extern bool test_init_and_recover_containers(bool print_all);
 TEST (init_and_recover_containers, test_init_and_recover_containers) {
   EXPECT_TRUE(test_init_and_recover_containers(FLAGS_print_all));

--- a/src/simulated_enclave.cc
+++ b/src/simulated_enclave.cc
@@ -1,3 +1,17 @@
+//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <openssl/ssl.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
@@ -15,21 +29,6 @@
 using std::string;
 using namespace certifier::framework;
 using namespace certifier::utilities;
-
-//  Copyright (c) 2021-22, VMware Inc, and the Certifier Authors.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 
 // simulated enclave data
 bool my_data_initialized = false;
@@ -63,8 +62,10 @@ bool simulated_GetPlatformClaim(signed_claim_message* out) {
   return true;
 }
 
-bool simulated_Init(const string& asn1_policy_cert, const string& attest_key_file,
-      const string& measurement_file, const string& attest_key_signed_claim_file) {
+bool simulated_Init(const string& asn1_policy_cert,
+                    const string& attest_key_file,
+                    const string& measurement_file,
+                    const string& attest_key_signed_claim_file) {
 
   int m_size = file_size(measurement_file);
   if (m_size < 0) {
@@ -141,7 +142,7 @@ bool simulated_Getmeasurement(int* size_out, byte* out) {
 const int max_seal_pad = 256;
 
 bool simulated_Seal(const string& enclave_type, const string& enclave_id,
-    int in_size, byte* in, int* size_out, byte* out) {
+                    int in_size, byte* in, int* size_out, byte* out) {
 
   const int iv_size = block_size;
   byte iv[iv_size];
@@ -163,7 +164,7 @@ bool simulated_Seal(const string& enclave_type, const string& enclave_id,
     return false;
   }
 
-  // input: concatinate measurment_size bytes of measurement and in
+  // input: concatinate measurement_size bytes of measurement and
   // then encrypt it and give it back.
   memcpy(input, (byte*)my_measurement.data(), my_measurement.size());
   memcpy(input + my_measurement.size(), in, in_size);
@@ -182,7 +183,7 @@ bool simulated_Seal(const string& enclave_type, const string& enclave_id,
 }
 
 bool simulated_Unseal(const string& enclave_type, const string& enclave_id,
-      int in_size, byte* in, int* size_out, byte* out) {
+                      int in_size, byte* in, int* size_out, byte* out) {
 
   int iv_size = block_size;
   byte iv[iv_size];
@@ -216,8 +217,8 @@ bool simulated_Unseal(const string& enclave_type, const string& enclave_id,
 // Attestation is a signed_claim_message
 // with a vse_claim_message claim
 bool simulated_Attest(const string& enclave_type,
-  int what_to_say_size, byte* what_to_say,
-  int* size_out, byte* out) {
+                      int what_to_say_size, byte* what_to_say,
+                      int* size_out, byte* out) {
 
   vse_attestation_report_info report_info;
   string serialized_report_info;
@@ -270,7 +271,7 @@ bool simulated_Attest(const string& enclave_type,
 }
 
 bool simulated_Verify(string& serialized_signed_report) {
-  string type("vse-attestation-report");
+                      string type("vse-attestation-report");
 
   if (!verify_report(type, serialized_signed_report, my_attestation_key)) {
     printf("simulated_Verify: verify_report failed\n");


### PR DESCRIPTION
This commit started off as an exercise to document external APIs of the Certifier Framework library. It ended up as:

- Add prologs to core extern APIs. Doc parameters
- Refactor code formatting & indentation of extern API interfaces and definitions to conform closer to coding standard
- Add new unit-test in `store_tests.cc`, `test_policy_store_signed_claims()`, to exercise policy-store interfaces handling signed_claims.
-----

NOTE: To the reviewer: About re-indentation of function definitions and declarations, I've tried to list parameters indented on the next-line (when needed) below the 1st param.

When line-length was getting way beyond 80-chars, I took the style of indenting params on the next line, at some # of tab stops.

(All this is a bit ad-hoc, but I think still improves overall readability of code.)