### PR TITLE
Fix to use the latest Islet SDK 

### DIFF
--- a/CI/scripts/test.sh
+++ b/CI/scripts/test.sh
@@ -791,9 +791,6 @@ function test-ISLET-SDK-shim_test() {
     echo "* Download ISLET SDK, build the library and run shim_test"
     echo "**********************************************************"
     echo " "
-    echo "****** WARNING! Skipped due to open issue #242, Fails on Ubuntu 22.04.4"
-    echo " "
-    return
 
     pushd src/islet > /dev/null 2>&1
 
@@ -819,9 +816,6 @@ function test-run_example-simple_app_under_islet-using-shim() {
     echo "* Test: Execute script to compile, build and run simple_app_under_islet using shim"
     echo "***********************************************************************************"
     echo " "
-    echo "****** WARNING! Skipped due to open issue #242, Fails on Ubuntu 22.04.4"
-    echo " "
-    return
 
     pushd ./sample_apps > /dev/null 2>&1
 

--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -1108,7 +1108,7 @@ function get_measurement_of_trusted_simple_app_under_islet() {
     # get_measurement_of_app_by_name "islet_example_app.exe"
 
     run_cmd
-    local mrenclave="6190EB90B293886C172EC644DAFB7E33EE2CEA6541ABE15300D96380DF525BF9"
+    local mrenclave="580bd77074f789f34841ea9920579ff29a59b9452b606f73811132b31c689da9"
     local measurement_file="example_app.measurement"
 
     run_pushd "${PROV_DIR}"

--- a/sample_apps/run_example.sh
+++ b/sample_apps/run_example.sh
@@ -1108,6 +1108,10 @@ function get_measurement_of_trusted_simple_app_under_islet() {
     # get_measurement_of_app_by_name "islet_example_app.exe"
 
     run_cmd
+    # The following mrenclave value should hardly change as it is
+    # a simulated version targeting x86_64. (The actual version only works on aarch64.)
+    # If you want to manually obtain the mrenclave value, refer to the islet CLI at the link below.
+    # https://github.com/islet-project/islet/blob/main/examples/cross-platform-e2ee/README.md#2-configure-measurements-and-policies
     local mrenclave="580bd77074f789f34841ea9920579ff29a59b9452b606f73811132b31c689da9"
     local measurement_file="example_app.measurement"
 

--- a/third_party/islet/setup.sh
+++ b/third_party/islet/setup.sh
@@ -29,14 +29,15 @@ ISLET_INC="$HERE/include"
 ISLET_LIB="$HERE/lib"
 
 TARGET_HDR="$ISLET_SDK/include/islet.h"
-TARGET_LIB="$ISLET/out/x86_64-unknown-linux-gnu/debug/libislet_sdk.so"
+TARGET_LIB="$ISLET/out/x86_64-unknown-linux-gnu/debug/libislet_sdk.a"
 
 # Sync islet
 cd "$HERE"
-wget https://github.com/Samsung/islet/archive/refs/tags/certifier-v1.0.1-beta.tar.gz
-tar xf certifier-v1.0.1-beta.tar.gz
 rm -rf "$ISLET"
-mv islet-certifier-v1.0.1-beta "$ISLET"
+git clone https://github.com/islet-project/islet.git "$ISLET"
+cd "$ISLET"
+git submodule update --init --depth 1 $ISLET/third-party/ciborium
+git submodule update --init --depth 1 $ISLET/third-party/coset
 
 # Install rust to build ISLET SDK
 "$ISLET/scripts/deps/rust.sh"


### PR DESCRIPTION
This PR addresses build errors in the Islet SDK. (Fixed https://github.com/ccc-certifier-framework/certifier-framework-for-confidential-computing/issues/244)

**Issues and Resolutions:**

1. **Issue:** Compatibility issues due to the upgrade of a third-party library used by the Islet SDK.
   **Fixing:** Upgraded to a compatible version and enforced explicit versioning to prevent automatic upgrades of the third-party library. (https://github.com/islet-project/islet/pull/315)

2. **Issue:** Upgrade of the MRENCLAVE value for the simulated version of Islet SDK targeting x86_64.
   **Fixing:** Updated to the upgraded value and added comments on how to obtain it. Although a shell script should ideally be written to fetch the actual value systematically, frequent changes are not anticipated, so only a description has been added for now.