### PR TITLE
Add cppcheck static analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
         # Need to resolve references to imports from 'google.protobuf'
         sudo apt install -y python3-protobuf
 
+        # cppchecker for static analysis
+        sudo apt install -y cppcheck
+
     #! -------------------------------------------------------------------------
     - name: report-osinfo
       run: ./CI/scripts/osinfo.sh
@@ -37,6 +40,12 @@ jobs:
     - name: test-src-code-formatting
       run: |
         ./CI/scripts/check-srcfmt.sh
+
+    #! -------------------------------------------------------------------------
+    #! Static analysis of source using cppcheck
+    - name: cppcheck-analysis
+      run: |
+        ./CI/scripts/cppcheck.sh
 
     #! -------------------------------------------------------------------------
     - name: test-core-certifier-programs

--- a/CI/scripts/cppcheck.sh
+++ b/CI/scripts/cppcheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# #############################################################################
+# Source code analysis with cppcheck. If anything fails, exit
+# with a non-zero $rc, and print an informational error message.
+# #############################################################################
+
+pushd "$(dirname "$0")" > /dev/null 2>&1 || exit
+
+cd ../../
+
+CERTIFIER_ROOT="$(pwd)"
+
+popd > /dev/null 2>&1 || exit
+
+cppcheck --error-exitcode=1 -i third_party --suppress=normalCheckLevelMaxBranches ${CERTIFIER_ROOT}
+rc=$?
+
+if [ $rc -ne 0 ]; then
+    echo "cppcheck static analysis failed. Run cppcheck --error-exitcode=1 -i third_party --suppress=normalCheckLevelMaxBranches CERTIFIER_ROOT to get more details."
+fi
+
+exit $rc

--- a/src/keystone/keystone_tests/keystone_shim.cc
+++ b/src/keystone/keystone_tests/keystone_shim.cc
@@ -19,23 +19,23 @@
 // END copied Keys.hpp
 
 // BEGIN copied Report.hpp
-struct enclave_report_t {
+struct _enclave_report_t {
   byte     hash[MDSIZE];
   uint64_t data_len;
   byte     data[ATTEST_DATA_MAXLEN];
   byte     signature[SIGNATURE_SIZE];
 };
 
-struct sm_report_t {
+struct _sm_report_t {
   byte hash[MDSIZE];
   byte public_key[PUBLIC_KEY_SIZE];
   byte signature[SIGNATURE_SIZE];
 };
 
-struct report_t {
-  struct enclave_report_t enclave;
-  struct sm_report_t      sm;
-  byte                    dev_public_key[PUBLIC_KEY_SIZE];
+struct _report_t {
+  struct _enclave_report_t enclave;
+  struct _sm_report_t      sm;
+  byte                     dev_public_key[PUBLIC_KEY_SIZE];
 };
 // END copied Report.hpp
 #endif
@@ -49,13 +49,13 @@ bool keystone_Attest(const int what_to_say_size,
                      int *     attestation_size_out,
                      byte *    attestation_out) {
   assert(what_to_say_size <= ATTEST_DATA_MAXLEN);
-  *attestation_size_out = sizeof(struct report_t);
+  *attestation_size_out = sizeof(struct _report_t);
   // unique-ify un-faked fields to avoid accidentally passing tests
-  for (unsigned int i = 0; i < sizeof(struct report_t); i++) {
+  for (unsigned int i = 0; i < sizeof(struct _report_t); i++) {
     attestation_out[i] = i ^ 17;
   }
-  struct report_t &report =
-      *reinterpret_cast<struct report_t *>(attestation_out);
+  struct _report_t &report =
+      *reinterpret_cast<struct _report_t *>(attestation_out);
   report.enclave.data_len = what_to_say_size;
   memcpy(report.enclave.data, what_to_say, what_to_say_size);
   // TODO: input default measurement
@@ -63,7 +63,7 @@ bool keystone_Attest(const int what_to_say_size,
 }
 
 // true = different
-bool nonhash_report_cmp(struct report_t &a, struct report_t &b) {
+static bool nonhash_report_cmp(struct _report_t &a, struct _report_t &b) {
   return (a.enclave.data_len != b.enclave.data_len)
          || memcmp(a.enclave.data, b.enclave.data, ATTEST_DATA_MAXLEN)
          || memcmp(a.enclave.signature, b.enclave.signature, SIGNATURE_SIZE)
@@ -78,11 +78,11 @@ bool keystone_Verify(const int what_to_say_size,
                      byte *    attestation,
                      int *     measurement_out_size,
                      byte *    measurement_out) {
-  assert(attestation_size == sizeof(struct report_t));
-  struct report_t &report = *reinterpret_cast<struct report_t *>(attestation);
+  assert(attestation_size == sizeof(struct _report_t));
+  struct _report_t &report = *reinterpret_cast<struct _report_t *>(attestation);
 
-  int             gold_attestation_size = 0;
-  struct report_t gold_report;
+  int              gold_attestation_size = 0;
+  struct _report_t gold_report;
   keystone_Attest(what_to_say_size,
                   what_to_say,
                   &gold_attestation_size,

--- a/utilities/appoint_platform.cc
+++ b/utilities/appoint_platform.cc
@@ -74,7 +74,7 @@ int main(int an, char **av) {
   an = 1;
 
   string usage_str("--policy_key=<file> --cert_file=<ark_cert.bin> "
-                   "--output=<output-file-name>";
+                   "--output=<output-file-name>");
   if (FLAGS_policy_key_file == "") {
     printf("No policy key\n");
     printf("%s %s\n", av[0], usage_str.c_str());
@@ -117,8 +117,8 @@ int main(int an, char **av) {
     return 1;
   }
 
-  string says_str("says");
-  string att_str("is-trusted-for-attestation");
+  string     says_str("says");
+  string     att_str("is-trusted-for-attestation");
   vse_clause cl1;
   if (!make_unary_vse_clause(plat_ent, att_str, &cl1)) {
     printf("Can't make clause 1\n");
@@ -137,7 +137,7 @@ int main(int an, char **av) {
     return 1;
   }
 
-  if (!write_file(FLAGS_output, out_str.size(), (byte*) out_str.data())) {
+  if (!write_file(FLAGS_output, out_str.size(), (byte *)out_str.data())) {
     printf("Can't write %s\n", FLAGS_output.c_str());
     return 1;
   }


### PR DESCRIPTION
Added cppcheck for static analysis. Skipping third_party code for now to avoid some external errors. Also, currently, the check level is normal. We'll increse coverage in the future.