### PR TITLE
Fix Ubuntu 20.04 installation docs: add missing UUID dependency and update deprecated Go commands 

### DIFF
--- a/Doc/install-certifier-Ubuntu-20.04.md
+++ b/Doc/install-certifier-Ubuntu-20.04.md
@@ -1,35 +1,40 @@
 # Install Certifier (Ubuntu 20.04)
 
-
 ### Setup Environment variables 
 
+```bash
 cd ~/Projects
 git clone https://github.com/ccc-certifier-framework/certifier-framework-for-confidential-computing.git
 
 export CERTIFIER=~/Projects/certifier-framework-for-confidential-computing
 export EXAMPLE_DIR=$CERTIFIER/sample_app
+```
 
 ### Install Dependencies
-```
-sudo apt install libgtest-dev libgflags-dev
+
+**Note**: The UUID library is required for compilation but was missing from the original documentation.
+
+```bash
+sudo apt update
+sudo apt install libgtest-dev libgflags-dev uuid-dev
 ```
 
 We note that the versioning of `protobuf` and `golang` matters. One shall not use the distribution directly `apt`-ed from Ubuntu. 
 
 Install the latest protobuf from source by 
-```
+```bash
 sudo apt install autoconf automake libtool curl make g++ unzip
 git clone https://github.com/protocolbuffers/protobuf.git
 cd protobuf
 git submodule update --init --recursive
 ./autogen.sh && ./configure
- make -j$(nproc)  &&  sudo make install
- sudo ldconfig # refresh shared library cache.
+make -j$(nproc) && sudo make install
+sudo ldconfig # refresh shared library cache.
 ``` 
-the detailed installation procedure can be found https://github.com/protocolbuffers/protobuf/blob/main/src/README.md. 
+The detailed installation procedure can be found https://github.com/protocolbuffers/protobuf/blob/main/src/README.md. 
 
 Install the latest `golang` by  
-```
+```bash
 sudo apt install wget 
 wget https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
@@ -37,61 +42,77 @@ export PATH=$PATH:/usr/local/go/bin && export PATH=$PATH:$(go env GOPATH)/bin
 rm go1.18.4.linux-amd64.tar.gz
 ```
 
-The protobuf compiler(protoc) for golang is installed by 
+**Updated Go Protobuf Installation**: The `go get` commands are deprecated. Use `go install` instead:
+```bash
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 ```
-go get github.com/golang/protobuf/proto
-go get google.golang.org/protobuf/cmd/protoc-gen-go
+
+**Alternative method** (if the above doesn't work, as referenced in the grpc.io quickstart):
+```bash
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 ```
 
 Ensure OpenSSL library and OpenSSL headers are installed or install by
-```
-sudo apt install openssl
-sudo apt install libssl-dev
+```bash
+sudo apt install openssl libssl-dev
 ```
 Current tests on Ubuntu are with OpenSSL 1.1.1f.
 
 ### Compile Certifier Library 
+
 The certifier library can be compiled by 
-```
- cd $CERTIFIER/src
- make -f certifier.mak
+```bash
+cd $CERTIFIER/src
+make -f certifier.mak
 
 cd $CERTIFIER/utilities
 make -f cert_utility.mak
 make -f policy_utilities.mak
 ```
 
-
 ### Build the Certifier Service 
 
 1. Compile the protobuf required by certifier service by 
-```
- cd $CERTIFIER/certifier_service/certprotos
- protoc --go_opt=paths=source_relative --go_out=. --go_opt=Mcertifier.proto= ./certifier.proto
+```bash
+cd $CERTIFIER/certifier_service/certprotos
+protoc --go_opt=paths=source_relative --go_out=. --go_opt=Mcertifier.proto= ./certifier.proto
 ```
 
 2. Install the certifier as go library by
-```
-go install  github.com/jlmucb/crypto@latest
+```bash
+go install github.com/jlmucb/crypto@latest
 # TODO: this is a workaround to an existing path issue 
 mkdir -p $(go env GOPATH)/src/github.com/jlmucb/crypto/v2
 sudo cp -r $CERTIFIER $(go env GOPATH)/src/github.com/jlmucb/crypto/v2
 ```
 
 3. Build the simple server
-```
- cd $CERTIFIER/certifier_service
- go build simpleserver.go
+```bash
+cd $CERTIFIER/certifier_service
+go build simpleserver.go
 ```
 If showing error of `go.mod not found`, run `go env -w GO111MODULE=off` before building. 
-
 
 ### Run `sample_app`
 
 To run sample application, follow the README in sample_app or directly run 
-```
+```bash
 cd $EXAMPLE_DIR
 chmod +x ./script
 ./script
 ```
 
+## Troubleshooting
+
+### Common Issues:
+
+1. **UUID library missing**: If you get `fatal error: uuid/uuid.h: No such file or directory`, ensure you've installed `uuid-dev`:
+   ```bash
+   sudo apt install uuid-dev
+   ```
+
+2. **Go protobuf installation issues**: The original `go get` commands are deprecated. Use the updated `go install` commands provided above, or refer to the official gRPC Go quickstart guide at https://grpc.io/docs/languages/go/quickstart/
+
+3. **Protobuf version conflicts**: Make sure to install protobuf from source rather than using the Ubuntu package to avoid version mismatches.


### PR DESCRIPTION
## Description

This PR fixes critical issues #252  in the Ubuntu 20.04 installation documentation that were causing build failures for new users following the official installation guide.

## Issues Fixed

1. **Missing UUID dependency**: Added `uuid-dev` package which is required for compilation but was missing from the original documentation
2. **Deprecated Go commands**: Updated deprecated `go get` commands to modern `go install` commands  
3. **Improved documentation structure**: Added troubleshooting section and better formatting

## Problem Context

- Users following the documentation encountered `fatal error: uuid/uuid.h: No such file or directory` during compilation
- The `go get` commands mentioned in the docs are deprecated and caused installation issues
- Multiple users reported these issues, confirmed by maintainer discussion

## Changes Made

- Added `uuid-dev` to the apt install dependencies list
- Replaced deprecated `go get` commands with `go install` equivalents
- Added alternative installation methods for Go protobuf tools
- Combined OpenSSL installation into single command
- Added comprehensive troubleshooting section
- Improved code block formatting and documentation structure

## Testing

- [x] Verified on clean Ubuntu 20.04 installation
- [x] All commands execute successfully with these changes
- [x] Build process completes without the UUID header error

## References

- Addresses build failures reported by multiple users
- Aligns with official [gRPC ](https://grpc.io/docs/languages/go/quickstart/)Go quickstart recommendations
- Follows modern Go toolchain best practices

---

> **Note**: This is a documentation-only change that fixes broken installation instructions. No code functionality is modified.

This PR fixes Ubuntu 20.04 build issues by updating dependencies and install steps. I’m eager to contribute more and learn more about it more please guide me  @jlmucb .