### PR TITLE
fix(docs): Fix OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![OpenSSF Best Practices] (https://www.bestpractices.dev/projects/8912/badge) (https://www.bestpractices.dev/projects/8912)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8912/badge)](https://www.bestpractices.dev/projects/8912)
 
 # Certifier Framework for Confidential Computing
 


### PR DESCRIPTION
This PR fixes the OpenSSF Best Practices badge Markdown in the README.md so the badge/link renders correctly.