### PR TITLE
Serialize table managers in save_principal_table_to_list

### DIFF
--- a/acl_lib/acl.cc
+++ b/acl_lib/acl.cc
@@ -340,7 +340,9 @@ bool acl_principal_table::save_principal_table_to_list(principal_list *pl) {
     principal_message *pm = pl->add_principals();
     pm->CopyFrom(principals_[i]);
   }
-  // Todo: add managers
+  for (int j = 0; j < num_managers_; j++) {
+    pl->add_table_managers(managers_[j]);
+  }
   principal_table_mutex_.unlock();
   return true;
 }


### PR DESCRIPTION

### GitHub PR Description
```markdown
### Summary
This PR implements serialization of `table_managers` in `acl_principal_table::save_principal_table_to_list` in `acl.cc`.

### Proposed Changes
- Iterates over `managers_` (up to `num_managers_`) and calls `pl->add_table_managers(managers_[j])` to ensure managers are saved to the protobuf message.
- Replaces the `// Todo: add managers` comment with the actual implementation.
