### PR TITLE
Fix mismatched verification key in public key tests

### DIFF
--- a/acl_lib/test_acl.cc
+++ b/acl_lib/test_acl.cc
@@ -1687,7 +1687,7 @@ bool test_public_keys(bool print_all) {
 #if 1
   // TODO: sometimes this faults
   if (!ecc_verify(Digest_method_sha_256,
-                  ecc_key,
+                  ecc_key2,
                   size_data,
                   data,
                   size_out,

--- a/src/support_tests.cc
+++ b/src/support_tests.cc
@@ -572,7 +572,7 @@ bool test_public_keys(bool print_all) {
 #if 1
   // TODO: sometimes this faults
   if (!ecc_verify(Digest_method_sha_256,
-                  ecc_key,
+                  ecc_key2,
                   size_data,
                   data,
                   size_out,


### PR DESCRIPTION

### GitHub PR Description
```markdown
### Summary
This PR fixes a bug in `test_public_keys` where `ecc_verify` was called with the wrong EC key (`ecc_key` instead of `ecc_key2`), causing verification failure and potential segmentation faults.

### Proposed Changes
- Modified `acl_lib/test_acl.cc` and `src/support_tests.cc` to use `ecc_key2` inside `ecc_verify` for the P-256 signature verification.
